### PR TITLE
Redesign visit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 
 [compat]
-julia = "1"
 AbstractTrees = "0.3"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/MethodAnalysis.jl
+++ b/src/MethodAnalysis.jl
@@ -2,6 +2,7 @@ module MethodAnalysis
 
 using AbstractTrees
 
+using Base: Callable, IdSet
 using Core: MethodInstance, SimpleVector, MethodTable
 
 export visit, call_type, instance, worlds
@@ -77,7 +78,9 @@ function instance(f, types)
             if mi.specTypes === tt
                 inst = mi
             end
+            return false
         end
+        true
     end
     return inst
 end

--- a/src/visit.jl
+++ b/src/visit.jl
@@ -58,55 +58,55 @@ julia> mods
 [...]
 """
 function visit(@nospecialize(operation); print::Bool=false)
-    visiting = IdSet{Any}()
+    visited = IdSet{Any}()
     for mod in Base.loaded_modules_array()
-        _visit(operation, mod, visiting, print)
+        _visit(operation, mod, visited, print)
     end
     return nothing
 end
 
 # These are non-keyword functions due to https://github.com/JuliaLang/julia/issues/34516
 
-function _visit(@nospecialize(operation), mod::Module, visiting::IdSet{Any}, print::Bool)
-    mod ∈ visiting && return nothing
-    push!(visiting, mod)
+function _visit(@nospecialize(operation), mod::Module, visited::IdSet{Any}, print::Bool)
+    mod ∈ visited && return nothing
+    push!(visited, mod)
     print && println("Module ", mod)
     if operation(mod)
         for nm in names(mod; all=true)
             if isdefined(mod, nm)
                 obj = getfield(mod, nm)
-                _visit(operation, obj, visiting, print)
+                _visit(operation, obj, visited, print)
             end
         end
     end
     return nothing
 end
 
-function _visit(@nospecialize(operation), @nospecialize(f::Callable), visiting::IdSet{Any}, print::Bool)
-    f ∈ visiting && return nothing
-    push!(visiting, f)
+function _visit(@nospecialize(operation), @nospecialize(f::Callable), visited::IdSet{Any}, print::Bool)
+    f ∈ visited && return nothing
+    push!(visited, f)
     print && println("Callable ", f)
     if operation(f)
         ml = methods(f)
-        _visit(operation, ml.mt, visiting, print)
+        _visit(operation, ml.mt, visited, print)
         Base.visit(ml.mt) do m
-            _visit(operation, m, visiting, print)
+            _visit(operation, m, visited, print)
         end
     end
     return nothing
 end
 
-function _visit(@nospecialize(operation), mt::MethodTable, visiting::IdSet{Any}, print::Bool)
-    mt ∈ visiting && return nothing
-    push!(visiting, mt)
+function _visit(@nospecialize(operation), mt::MethodTable, visited::IdSet{Any}, print::Bool)
+    mt ∈ visited && return nothing
+    push!(visited, mt)
     print && println("MethodTable ", mt)
     operation(mt)
     return nothing
 end
 
-function _visit(@nospecialize(operation), m::Method, visiting::IdSet{Any}, print::Bool)
-    m ∈ visiting && return nothing
-    push!(visiting, m)
+function _visit(@nospecialize(operation), m::Method, visited::IdSet{Any}, print::Bool)
+    m ∈ visited && return nothing
+    push!(visited, m)
     print && println("Method ", m)
     if operation(m)
         for fn in (:specializations, :invokes)
@@ -115,10 +115,10 @@ function _visit(@nospecialize(operation), m::Method, visiting::IdSet{Any}, print
                 if spec === nothing
                 elseif isa(spec, Core.TypeMapEntry) || isa(spec, Core.TypeMapLevel)
                     Base.visit(spec) do mi
-                        _visit(operation, mi, visiting, print)
+                        _visit(operation, mi, visited, print)
                     end
                 elseif isa(spec, Core.SimpleVector)
-                    _visit(operation, spec, visiting, print)
+                    _visit(operation, spec, visited, print)
                 else
                     error("unhandled type ", typeof(spec), ": ", spec)
                 end
@@ -128,22 +128,22 @@ function _visit(@nospecialize(operation), m::Method, visiting::IdSet{Any}, print
     return nothing
 end
 
-function _visit(@nospecialize(operation), sv::SimpleVector, visiting::IdSet{Any}, print::Bool)
+function _visit(@nospecialize(operation), sv::SimpleVector, visited::IdSet{Any}, print::Bool)
     for i = 1:length(sv)
         if isassigned(sv, i)
-            _visit(operation, sv[i], visiting, print)
+            _visit(operation, sv[i], visited, print)
         end
     end
     return nothing
 end
 
-function _visit(@nospecialize(operation), mi::MethodInstance, visiting::IdSet{Any}, print::Bool)
-    mi ∈ visiting && return nothing
-    push!(visiting, mi)
+function _visit(@nospecialize(operation), mi::MethodInstance, visited::IdSet{Any}, print::Bool)
+    mi ∈ visited && return nothing
+    push!(visited, mi)
     print && println(mi)
     if operation(mi)
         if isdefined(mi, :cache)
-            _visit(operation, mi.cache, visiting, print)
+            _visit(operation, mi.cache, visited, print)
         end
     end
     return nothing
@@ -163,7 +163,7 @@ if isdefined(Core, :CodeInstance)
     end
 end
 
-_visit(@nospecialize(operation), @nospecialize(x), visiting::IdSet{Any}, print::Bool) = nothing
+_visit(@nospecialize(operation), @nospecialize(x), visited::IdSet{Any}, print::Bool) = nothing
 
 """
     visit_backedges(operation, obj)
@@ -176,61 +176,53 @@ contain `MethodTable`s.
 
 `operation(edge)` should return `true` if the backedges of `edge` should in turn be visited,
 `false` otherwise.
+However, no `MethodInstance` will be visited more than once.
 
 The set of visited objects includes `obj` itself.
 For example, `visit_backedges(operation, f::Function)` will visit all methods of `f`,
 and this in turn will visit all MethodInstances of these methods.
 """
-visit_backedges(operation, obj) =
-    visit_backedges(operation, obj, Set{Union{MethodInstance,MethodTable}}())
-
-function _visit_backedges(operation, mi::MethodInstance, visited)
-    if isdefined(mi, :backedges)
-        for edge in mi.backedges
-            visit_backedges(operation, edge, visited)
-        end
-    end
-    return nothing
+function visit_backedges(@nospecialize(operation), obj)
+    visited = IdSet{MethodInstance}()
+    visit_backedges(operation, obj, visited)
 end
 
-function visit_backedges(operation, mi::MethodInstance, visited)
-    mi ∈ visited && return nothing
-    push!(visited, mi)
-    operation(mi) && _visit_backedges(operation, mi, visited)
-    return nothing
-end
-
-function visit_backedges(operation, mt::MethodTable, visited)
-    mt ∈ visited && return nothing
-    push!(visited, mt)
-    if isdefined(mt, :backedges)
-        for i = 1:2:length(mt.backedges)
-            sig, mi = mt.backedges[i], mt.backedges[i+1]
-            if operation(sig=>mi) && mi ∉ visited
-                push!(visited, mi)
-                _visit_backedges(operation, mi, visited)
+function visit_backedges(@nospecialize(operation), obj, visited::IdSet{MethodInstance})
+    function opwrapper(@nospecialize(x))
+        if isa(x, MethodInstance)
+            _visit_backedges(operation, x, visited)
+            return false
+        elseif isa(x, MethodTable)
+            mt = x::MethodTable
+            if isdefined(mt, :backedges)
+                sigmis = mt.backedges::Vector{Any}
+                for i = 1:2:length(sigmis)
+                    sig, mi = sigmis[i], sigmis[i+1]
+                    _visit_backedges(operation, Pair{Any,MethodInstance}(sig, mi), visited)
+                end
             end
-        end
-    end
-    return nothing
-end
-
-function visit_backedges(operation, m::Method, visited)
-    visit(m) do mi
-        if isa(mi, MethodInstance)
-            visit_backedges(operation, mi, visited)
             return false
         end
-        true
+        return true
+    end
+
+    visit(opwrapper, obj)
+end
+
+function _visit_backedges(@nospecialize(operation), mi::MethodInstance, visited)
+    mi ∈ visited && return nothing
+    push!(visited, mi)
+    if operation(mi) && isdefined(mi, :backedges)
+        for edge in mi.backedges
+            _visit_backedges(operation, edge, visited)
+        end
     end
     return nothing
 end
 
-function visit_backedges(operation, f::Callable, visited)
-    ml = methods(f)
-    visit_backedges(operation, ml.mt, visited)
-    for m in ml
-        visit_backedges(operation, m, visited)
+function _visit_backedges(@nospecialize(operation), misig::Pair{Any,MethodInstance}, visited)
+    if operation(misig)
+        _visit_backedges(operation, misig.second, visited)
     end
     return nothing
 end

--- a/src/visit.jl
+++ b/src/visit.jl
@@ -1,83 +1,169 @@
 """
+    visit(operation, obj; print=false)
+
+Scan `obj` and all of its "sub-objects" (e.g., functions if `obj::Module`,
+methods if `obj::Function`, etc.) recursively.
+`operation(x)` should return `true` if `visit` should descend
+into "sub-objects" of `x`. 
+
+# Example
+
+To collect all MethodInstances of a function,
+
+```jldoctest; setup=:(using MethodAnalysis), filter=r"[dd]-element"
+julia> mis = Core.MethodInstance[];
+
+julia> visit(findfirst) do x
+           if isa(x, Core.MethodInstance)
+               push!(mis, x)
+               return false
+           end
+           true
+       end
+
+julia> mis
+31-element Array{Core.MethodInstance,1}:
+ MethodInstance for findfirst(::BitArray{1})
+[...]
+```    
+"""
+visit(@nospecialize(operation), @nospecialize(obj); print::Bool=false) =
+    _visit(operation, obj, IdSet{Any}(), print)
+
+"""
     visit(operation)
 
-Scan all loaded modules with `operation`. `operation(x)` should handle `x::Module`, `x::Function`,
-`x::Method`, `x::MethodInstance`. Any return value from `operation` will be discarded.
+Scan all loaded modules with `operation`.
+
+# Example
+
+Collect all loaded modules, even if they are internal.
+
+```jldoctest; setup=:(using MethodAnalysis), filter=r"[ddd]-element"
+julia> mods = Module[];
+
+julia> visit() do x
+           if isa(x, Module)
+               push!(mods, x)
+               return true
+           end
+           false
+       end
+```
+
+julia> mods
+113-element Array{Module,1}:
+ Random
+ Random.DSFMT
+[...]
 """
-function visit(operation; print=true)
-    visiting=Set{Module}()
+function visit(@nospecialize(operation); print::Bool=false)
+    visiting = IdSet{Any}()
     for mod in Base.loaded_modules_array()
-        visit(operation, mod, visiting; print=print)
+        _visit(operation, mod, visiting, print)
     end
     return nothing
 end
 
-function visit(operation, mod::Module, visiting=Set{Module}(); print=true)
+# These are non-keyword functions due to https://github.com/JuliaLang/julia/issues/34516
+
+function _visit(@nospecialize(operation), mod::Module, visiting::IdSet{Any}, print::Bool)
     mod ∈ visiting && return nothing
     push!(visiting, mod)
-    operation(mod)
     print && println("Module ", mod)
-    for nm in names(mod; all=true)
-        if isdefined(mod, nm)
-            obj = getfield(mod, nm)
-            if isa(obj, Module)
-                visit(operation, obj, visiting; print=print)
-            else
-                visit(operation, obj)
+    if operation(mod)
+        for nm in names(mod; all=true)
+            if isdefined(mod, nm)
+                obj = getfield(mod, nm)
+                _visit(operation, obj, visiting, print)
             end
         end
     end
     return nothing
 end
 
-function visit(operation, f::Function)
-    operation(f)
-    Base.visit(methods(f).mt) do m
-        visit(operation, m)
+function _visit(@nospecialize(operation), @nospecialize(f::Callable), visiting::IdSet{Any}, print::Bool)
+    f ∈ visiting && return nothing
+    push!(visiting, f)
+    print && println("Callable ", f)
+    if operation(f)
+        ml = methods(f)
+        _visit(operation, ml.mt, visiting, print)
+        Base.visit(ml.mt) do m
+            _visit(operation, m, visiting, print)
+        end
     end
     return nothing
 end
 
-function visit(operation, m::Method)
-    operation(m)
-    for fn in (:specializations,) # :invokes)   not sure if invokes contains additional methods
-        if isdefined(m, fn)
-            spec = getfield(m, fn)
-            if spec === nothing
-            elseif isa(spec, Core.TypeMapEntry) || isa(spec, Core.TypeMapLevel)
-                Base.visit(spec) do mi
-                    visit(operation, mi)
+function _visit(@nospecialize(operation), mt::MethodTable, visiting::IdSet{Any}, print::Bool)
+    mt ∈ visiting && return nothing
+    push!(visiting, mt)
+    print && println("MethodTable ", mt)
+    operation(mt)
+    return nothing
+end
+
+function _visit(@nospecialize(operation), m::Method, visiting::IdSet{Any}, print::Bool)
+    m ∈ visiting && return nothing
+    push!(visiting, m)
+    print && println("Method ", m)
+    if operation(m)
+        for fn in (:specializations, :invokes)
+            if isdefined(m, fn)
+                spec = getfield(m, fn)
+                if spec === nothing
+                elseif isa(spec, Core.TypeMapEntry) || isa(spec, Core.TypeMapLevel)
+                    Base.visit(spec) do mi
+                        _visit(operation, mi, visiting, print)
+                    end
+                elseif isa(spec, Core.SimpleVector)
+                    _visit(operation, spec, visiting, print)
+                else
+                    error("unhandled type ", typeof(spec), ": ", spec)
                 end
-            elseif isa(spec, Core.SimpleVector)
-                visit(operation, spec)
-            else
-                error("unhandled type ", typeof(spec), ": ", spec)
             end
         end
     end
     return nothing
 end
 
-function visit(operation, sv::SimpleVector)
+function _visit(@nospecialize(operation), sv::SimpleVector, visiting::IdSet{Any}, print::Bool)
     for i = 1:length(sv)
         if isassigned(sv, i)
-            visit(operation, sv[i])
+            _visit(operation, sv[i], visiting, print)
         end
     end
     return nothing
 end
 
-function visit(operation, mi::MethodInstance)
-    operation(mi)
-    if isdefined(mi, :cache)
-        visit(operation, mi.cache)
+function _visit(@nospecialize(operation), mi::MethodInstance, visiting::IdSet{Any}, print::Bool)
+    mi ∈ visiting && return nothing
+    push!(visiting, mi)
+    print && println(mi)
+    if operation(mi)
+        if isdefined(mi, :cache)
+            _visit(operation, mi.cache, visiting, print)
+        end
     end
     return nothing
 end
 
-# TODO: CodeInstance
+if isdefined(Core, :CodeInstance)
+    function _visit(@nospecialize(operation), ci::Core.CodeInstance, visited::IdSet{Any}, print::Bool)
+        ci ∈ visited && return nothing
+        push!(visited, ci)
+        print && println(ci)
+        if operation(ci)
+            if isdefined(ci, :next)
+                _visit(operation, ci.next, visited, print)
+            end
+        end
+        return nothing
+    end
+end
 
-visit(operation, x) = nothing
+_visit(@nospecialize(operation), @nospecialize(x), visiting::IdSet{Any}, print::Bool) = nothing
 
 """
     visit_backedges(operation, obj)
@@ -133,12 +219,14 @@ function visit_backedges(operation, m::Method, visited)
     visit(m) do mi
         if isa(mi, MethodInstance)
             visit_backedges(operation, mi, visited)
+            return false
         end
+        true
     end
     return nothing
 end
 
-function visit_backedges(operation, f::Function, visited)
+function visit_backedges(operation, f::Callable, visited)
     ml = methods(f)
     visit_backedges(operation, ml.mt, visited)
     for m in ml

--- a/src/visit.jl
+++ b/src/visit.jl
@@ -1,16 +1,18 @@
 """
-    visit(operation, obj; print=false)
+    visit(operation, obj; print::Bool=false)
 
 Scan `obj` and all of its "sub-objects" (e.g., functions if `obj::Module`,
 methods if `obj::Function`, etc.) recursively.
 `operation(x)` should return `true` if `visit` should descend
-into "sub-objects" of `x`. 
+into "sub-objects" of `x`.
+
+If `print` is `true`, each visited object is printed to standard output.
 
 # Example
 
 To collect all MethodInstances of a function,
 
-```jldoctest; setup=:(using MethodAnalysis), filter=r"[dd]-element"
+```jldoctest; setup=:(using MethodAnalysis), filter=r"[0-9][0-9]"
 julia> mis = Core.MethodInstance[];
 
 julia> visit(findfirst) do x
@@ -21,25 +23,26 @@ julia> visit(findfirst) do x
            true
        end
 
-julia> mis
-31-element Array{Core.MethodInstance,1}:
- MethodInstance for findfirst(::BitArray{1})
-[...]
-```    
+julia> length(mis)
+34
+```
+
+The exact number of MethodInstances will depend on what code you've run in your Julia session.
 """
 visit(@nospecialize(operation), @nospecialize(obj); print::Bool=false) =
     _visit(operation, obj, IdSet{Any}(), print)
 
 """
-    visit(operation)
+    visit(operation; print::Bool=false)
 
 Scan all loaded modules with `operation`.
+See [`visit(operation, obj)`](@ref) for further detail.
 
 # Example
 
 Collect all loaded modules, even if they are internal.
 
-```jldoctest; setup=:(using MethodAnalysis), filter=r"[ddd]-element"
+```jldoctest; setup=:(using MethodAnalysis), filter=r"[0-9][0-9][0-9]-element"
 julia> mods = Module[];
 
 julia> visit() do x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,8 +24,9 @@ end
     @test Outer.callcallh(1)
 
     mis = Core.MethodInstance[]
-    visit(Outer; print=false) do x
+    visit(Outer) do x
         isa(x, Core.MethodInstance) && push!(mis, x)
+        true
     end
     @test any(mi->mi.specTypes === Tuple{typeof(Outer.f), Nothing}, mis)
     @test count(mi->mi.specTypes === Tuple{typeof(Outer.Inner.g), String}, mis) == 1
@@ -38,10 +39,12 @@ end
     @test !any(mi->mi.specTypes === Tuple{typeof(Outer.callcallh), Float64}, mis)
 
     mods = Module[]
-    visit(;print=false) do x
+    visit() do x
         if isa(x, Module)
             push!(mods, x)
+            return true
         end
+        false
     end
     @test all(in(mods), Base.loaded_modules_array())
     @test Base ∈ mods


### PR DESCRIPTION
This extensively reworks `visit` and `visit_backedges`:

- it requires `operation` to return a Bool to control descent
- it extends the "visit-once" logic to all objects
- it extends printing to all objects but turns it off by default
- it greatly improves performance with `@nospecialize` annotations
- it separates user-interface from internals (`visit` vs `_visit`)
- it supports more types (`MethodTable`, `CodeInstance`)
- it orthogonalizes `visit` and `visit_backedges`, allowing the latter to handle everything except the backedges themselves.

Closes #2