### PR TITLE
Handle type methodtables properly

### DIFF
--- a/src/visit.jl
+++ b/src/visit.jl
@@ -93,7 +93,7 @@ function _visit(@nospecialize(operation), @nospecialize(f::Callable), visited::I
     if operation(f)
         ml = methods(f)
         _visit(operation, ml.mt, visited, print)
-        Base.visit(ml.mt) do m
+        for m in ml.ms
             _visit(operation, m, visited, print)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,12 @@ end
         true
     end
     @test nitems[] == 0
+
+    # Handle constructors properly
+    visit(IndexStyle) do m
+        isa(m, Method) && @test Base.unwrap_unionall(m.sig).parameters[1].parameters[1] === IndexStyle
+        return m === IndexStyle
+    end
 end
 
 @testset "Backedges" begin


### PR DESCRIPTION
For types, the `.mt` field is for `Type`; `.ms` is the constructor method list. Formerly we were collecting all methods of `Type` any time we visited a type (oops...).