### PR TITLE
Implement `findcallers`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0.25"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,6 @@ makedocs(;
     repo="https://github.com/timholy/MethodAnalysis.jl/blob/{commit}{path}#L{line}",
     sitename="MethodAnalysis.jl",
     authors="Tim Holy <tim.holy@gmail.com>",
-    assets=String[],
 )
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,12 +52,13 @@ julia> foo(::AbstractVector) = 1
 foo (generic function with 1 method)
 
 julia> methodinstance(foo, (Vector{Int},))   # we haven't called it yet, so it's not compiled
+MethodInstance for foo(::Vector{Int64})
 
 julia> foo([1,2])
 1
 
 julia> methodinstance(foo, (Vector{Int},))
-MethodInstance for foo(::Array{Int64,1})
+MethodInstance for foo(::Vector{Int64})
 ```
 
 ### Collecting a subset of MethodInstances for a particular function
@@ -73,15 +74,15 @@ julia> visit(findfirst) do item
        end
 
 julia> mis
-1-element Array{Core.MethodInstance,1}:
- MethodInstance for findfirst(::BitArray{1})
+1-element Vector{Core.MethodInstance}:
+ MethodInstance for findfirst(::BitVector)
 ```
 
 We checked that the length was 2, rather than 1, because the first parameter is the function type itself:
 
 ```jldoctest findfirst
 julia> mis[1].specTypes
-Tuple{typeof(findfirst),BitArray{1}}
+Tuple{typeof(findfirst),BitVector}
 ```
 
 There's also a convenience shortcut:
@@ -96,10 +97,10 @@ Let's see all the compiled instances of `Base.setdiff` and their immediate calle
 
 ```jldoctest; setup=(using MethodAnalysis)
 julia> direct_backedges(setdiff)
-3-element Array{Any,1}:
+3-element Vector{Any}:
  MethodInstance for setdiff(::Base.KeySet{Any,Dict{Any,Any}}, ::Base.KeySet{Any,Dict{Any,Any}}) => MethodInstance for keymap_merge(::Dict{Char,Any}, ::Dict{Any,Any})
  MethodInstance for setdiff(::Base.KeySet{Any,Dict{Any,Any}}, ::Base.KeySet{Any,Dict{Any,Any}}) => MethodInstance for keymap_merge(::Any, ::Dict{Any,Any})
-                         MethodInstance for setdiff(::Array{Base.UUID,1}, ::Array{Base.UUID,1}) => MethodInstance for deps_graph(::Pkg.Types.Context, ::Dict{Base.UUID,String}, ::Dict{Base.UUID,Pkg.Types.VersionSpec}, ::Dict{Base.UUID,Pkg.Resolve.Fixed})
+                           MethodInstance for setdiff(::Vector{Base.UUID}, ::Vector{Base.UUID}) => MethodInstance for deps_graph(::Pkg.Types.Context, ::Dict{Base.UUID,String}, ::Dict{Base.UUID,Pkg.Types.VersionSpec}, ::Dict{Base.UUID,Pkg.Resolve.Fixed})
 ```
 
 ### Printing backedges as a tree
@@ -108,18 +109,15 @@ MethodAnalysis uses [AbstractTrees](https://github.com/JuliaCollections/Abstract
 
 ```jldoctest; setup=:(using MethodAnalysis)
 julia> mi = methodinstance(findfirst, (BitVector,))
-MethodInstance for findfirst(::BitArray{1})
+MethodInstance for findfirst(::BitVector)
 
 julia> MethodAnalysis.print_tree(mi)
-MethodInstance for findfirst(::BitArray{1})
+MethodInstance for findfirst(::BitVector)
 ├─ MethodInstance for prune_graph!(::Graph)
 │  └─ MethodInstance for #simplify_graph!#111(::Bool, ::typeof(simplify_graph!), ::Graph, ::Set{Int64})
 │     └─ MethodInstance for simplify_graph!(::Graph, ::Set{Int64})
 │        └─ MethodInstance for simplify_graph!(::Graph)
-│           ├─ MethodInstance for trigger_failure!(::Graph, ::Array{Int64,1}, ::Tuple{Int64,Int64})
-│           │  ⋮
-│           │
-│           └─ MethodInstance for resolve_versions!(::Context, ::Array{PackageSpec,1})
+│           └─ MethodInstance for resolve_versions!(::Context, ::Vector{PackageSpec})
 │              ⋮
 │
 └─ MethodInstance for update_solution!(::SolutionTrace, ::Graph)
@@ -138,10 +136,10 @@ MethodInstance for findfirst(::BitArray{1})
       │
       └─ MethodInstance for maxsum(::Graph)
          └─ MethodInstance for resolve(::Graph)
-            ├─ MethodInstance for trigger_failure!(::Graph, ::Array{Int64,1}, ::Tuple{Int64,Int64})
+            ├─ MethodInstance for trigger_failure!(::Graph, ::Vector{Int64}, ::Tuple{Int64,Int64})
             │  ⋮
             │
-            └─ MethodInstance for resolve_versions!(::Context, ::Array{PackageSpec,1})
+            └─ MethodInstance for resolve_versions!(::Context, ::Vector{PackageSpec})
                ⋮
 ```
 
@@ -181,8 +179,8 @@ with_all_backedges
 ### utilities
 
 ```@docs
-instance
-instances
+methodinstance
+methodinstances
 call_type
 findcallers
 worlds

--- a/src/MethodAnalysis.jl
+++ b/src/MethodAnalysis.jl
@@ -5,7 +5,7 @@ using AbstractTrees
 using Base: Callable, IdSet
 using Core: MethodInstance, CodeInfo, SimpleVector, MethodTable
 
-export visit, call_type, methodinstance, methodinstances, worlds, findcallers
+export visit, call_type, methodinstance, methodinstances, worlds  # findcallers is exported from its own file
 export visit_backedges, all_backedges, with_all_backedges, terminal_backedges, direct_backedges
 
 include("visit.jl")
@@ -130,135 +130,9 @@ function methodinstances(top=())
     return mis
 end
 
-function get_typed_instances!(srcs, mi::MethodInstance, world, interp)
-    # This is essentially take from code_typed_by_type
-    tt = mi.specTypes
-    matches = Base._methods_by_ftype(tt, -1, world)
-    if matches === false
-        error("signature $(item.specTypes) does not correspond to a generic function")
-    end
-    for match in matches
-        match.method == mi.def || continue
-        meth = Base.func_for_method_checked(match.method, tt, match.sparams)
-        (src, ty) = Core.Compiler.typeinf_code(interp, meth, match.spec_types, match.sparams, false)
-        push!(srcs, src)
-    end
-    return srcs
+if isdefined(Core, :MethodMatch)
+    include("findcallers.jl")
 end
-
-function get_typed_instances(mi::MethodInstance; world=typemax(UInt), interp=Core.Compiler.NativeInterpreter(world))
-    return get_typed_instances!(CodeInfo[], mi, world, interp)
-end
-
-"""
-    callers = findcallers(f, argmatch::Union{Nothing,Function}, mis; callhead=:call | :iterate)
-
-Find "static" callers of a function `f` with *inferred* argument types for which `argmatch(types)` returns true.
-Optionally pass `nothing` for `argmatch` to allow any calls to `f`.
-`mis` is the list of `MethodInstance`s you want to check, for example obtained from [`instances`](@ref).
-
-`callhead` controls whether you're looking for "static" dispatch (`:call`) or a splatted call (`:iterate`).
-
-`callers` is a vector of tuples `t`, where `t[1]` is the `MethodInstance`, `t[2]` is the corresponding `CodeInfo`,
-`t[3]` is the statement number on which the call occurs, and `t[4]` holds the inferred argument types.
-
-# Examples
-
-```julia
-f(x) = rand()
-function g()
-    a = f(1.0)
-    z = Any[7]
-    b = f(z[1]::Integer)
-    c = f(z...)
-    return nothing
-end
-
-g()
-mis = union(methodinstances(f), methodinstances(g))
-
-# callhead = :call is the default
-callers1 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis)
-
-# Get the partial-inference case with known number of arguments (this is definitely :call)
-callers2 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Integer, mis; callhead=:call)
-
-# Get the splat call
-callers3 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
-"""
-function findcallers(f, argmatch::Union{Function,Nothing}, mis::AbstractVector{Core.MethodInstance};
-                     callhead::Symbol=:call, world=typemax(UInt), interp=Core.Compiler.NativeInterpreter(world))
-    callhead === :call || callhead === :invoke || callhead === :iterate || error(":call and :invoke are supported, got ", callhead)
-    # if callhead === :iterate
-    #     return findcallers(mis, GlobalRef(Core, :_apply_iterate), argt->(argtargmatch(argt[4:end]); callhead=:call)
-    # end
-    extract(a) = isa(a, Core.Const) ? typeof(a.val) :
-                 isa(a, Core.PartialStruct) ? (a.typ <: Tuple{Any} ? a.typ.parameters[1] : a.typ) :
-                 isa(a,Type) ? a : typeof(a)
-    # Construct a GlobalRef version of `f`
-    ref = GlobalRef(parentmodule(f), nameof(f))
-    callers = Tuple{MethodInstance,CodeInfo,Int,Vector{Any}}[]
-    srcs = CodeInfo[]
-    for item in mis
-        empty!(srcs)
-        try
-            get_typed_instances!(srcs, item, world, interp)
-        catch err
-            # println("skipping ", item, ": ", err)
-            continue
-        end
-        for src in srcs
-            for (i, stmt) in enumerate(src.code)
-                if isa(stmt, Expr)
-                    g = nothing
-                    if stmt.head === :(=)
-                        stmt = stmt.args[2]   # call must come from right hand side of assignment
-                        isa(stmt, Expr) || continue
-                    end
-                    stmt = stmt::Expr
-                    if callhead === :iterate && stmt.head === :call && isglobalref(stmt.args[1], Core, :_apply_iterate)
-                        if isa(stmt.args[3], GlobalRef)  # TODO: handle SSAValues?
-                            g = stmt.args[3]::GlobalRef
-                        end
-                    elseif stmt.head === callhead && isa(stmt.args[1], GlobalRef)  # TODO: handle SSAValue?
-                        g = stmt.args[1]::GlobalRef
-                    end
-                    if isa(g, GlobalRef)
-                        if isglobalref(g, ref.mod, ref.name) ||
-                           (isdefined(g.mod, g.name) && getfield(g.mod, g.name) === f)
-                            # Collect the arg types
-                            argtypes = []
-                            for i = (callhead === :iterate ? 4 : 2):length(stmt.args)
-                                a = stmt.args[i]
-                                if isa(a, Core.SSAValue)
-                                    push!(argtypes, extract(src.ssavaluetypes[a.id]))
-                                elseif isa(a, Core.SlotNumber)
-                                    push!(argtypes, extract(src.slottypes[a.id]))
-                                else
-                                    push!(argtypes, extract(a))
-                                end
-                            end
-                            # Check whether the types match
-                            if argmatch === nothing
-                                push!(callers, (item, src, i, argtypes))
-                                break
-                            else
-                                if argmatch(argtypes)
-                                    push!(callers, (item, src, i, argtypes))
-                                    break
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-    return callers
-end
-
-isglobalref(@nospecialize(g), mod::Module, name::Symbol) = isa(g, GlobalRef) && g.mod === mod && g.name === name
-
 
 # AbstractTrees interface
 AbstractTrees.children(mi::MethodInstance) = isdefined(mi, :backedges) ? mi.backedges : []

--- a/src/MethodAnalysis.jl
+++ b/src/MethodAnalysis.jl
@@ -3,9 +3,9 @@ module MethodAnalysis
 using AbstractTrees
 
 using Base: Callable, IdSet
-using Core: MethodInstance, SimpleVector, MethodTable
+using Core: MethodInstance, CodeInfo, SimpleVector, MethodTable
 
-export visit, call_type, instance, worlds
+export visit, call_type, methodinstance, methodinstances, worlds, findcallers
 export visit_backedges, all_backedges, with_all_backedges, terminal_backedges, direct_backedges
 
 include("visit.jl")
@@ -65,8 +65,8 @@ end
 equal(p1::Pair, p2::Pair) = p1.second == p2.second && equal(p1.first, p2.first)
 
 """
-    mi = instance(f, types)
-    mi = instance(tt::Type{<:Tuple})
+    mi = methodinstance(f, types)
+    mi = methodinstance(tt::Type{<:Tuple})
 
 Return the `MethodInstance` `mi` for function `f` and the given `types`,
 or for the complete signature `tt`.
@@ -79,18 +79,18 @@ julia> f(x, y::String) = 2x; f(x, y::Number) = x + y;
 
 julia> f(1, "hi"); f(1, 1.0);
 
-julia> instance(f, (Int, String))
+julia> methodinstance(f, (Int, String))
 MethodInstance for f(::Int64, ::String)
 
-julia> instance(Tuple{typeof(f), Int, String})
+julia> methodinstance(Tuple{typeof(f), Int, String})
 MethodInstance for f(::Int64, ::String)
 ```
 """
-function instance(@nospecialize(f), @nospecialize(types))
+function methodinstance(@nospecialize(f), @nospecialize(types))
     if types isa Tuple
         m = which(f, types)
         tt = Tuple{typeof(f), types...}
-        return instance(m, tt)
+        return methodinstance(m, tt)
     end
     inst = nothing
     visit(f) do mi
@@ -104,12 +104,166 @@ function instance(@nospecialize(f), @nospecialize(types))
     end
     return inst
 end
-function instance(@nospecialize(types))
+function methodinstance(@nospecialize(types))
     f, argt = call_type(types)
     m = which(f, argt)
-    return instance(m, types)
+    return methodinstance(m, types)
 end
 
+"""
+    methodinstances()
+    methodinstances(mod::Module)
+    methodinstances(f)
+
+Collect all `MethodInstance`s, optionally restricting them to a particular module or function.
+"""
+function methodinstances(top=())
+    if isa(top, Module) || isa(top, Function) || isa(top, Type)
+        top = (top,)
+    end
+    mis = Core.MethodInstance[]
+    visit(top...) do item
+        isa(item, Core.MethodInstance) || return true
+        push!(mis, item)
+        false
+    end
+    return mis
+end
+
+function get_typed_instances!(srcs, mi::MethodInstance, world, interp)
+    # This is essentially take from code_typed_by_type
+    tt = mi.specTypes
+    matches = Base._methods_by_ftype(tt, -1, world)
+    if matches === false
+        error("signature $(item.specTypes) does not correspond to a generic function")
+    end
+    for match in matches
+        match.method == mi.def || continue
+        meth = Base.func_for_method_checked(match.method, tt, match.sparams)
+        (src, ty) = Core.Compiler.typeinf_code(interp, meth, match.spec_types, match.sparams, false)
+        push!(srcs, src)
+    end
+    return srcs
+end
+
+function get_typed_instances(mi::MethodInstance; world=typemax(UInt), interp=Core.Compiler.NativeInterpreter(world))
+    return get_typed_instances!(CodeInfo[], mi, world, interp)
+end
+
+"""
+    callers = findcallers(f, argmatch::Union{Nothing,Function}, mis; callhead=:call | :iterate)
+
+Find "static" callers of a function `f` with *inferred* argument types for which `argmatch(types)` returns true.
+Optionally pass `nothing` for `argmatch` to allow any calls to `f`.
+`mis` is the list of `MethodInstance`s you want to check, for example obtained from [`instances`](@ref).
+
+`callhead` controls whether you're looking for "static" dispatch (`:call`) or a splatted call (`:iterate`).
+
+`callers` is a vector of tuples `t`, where `t[1]` is the `MethodInstance`, `t[2]` is the corresponding `CodeInfo`,
+`t[3]` is the statement number on which the call occurs, and `t[4]` holds the inferred argument types.
+
+# Examples
+
+```julia
+f(x) = rand()
+function g()
+    a = f(1.0)
+    z = Any[7]
+    b = f(z[1]::Integer)
+    c = f(z...)
+    return nothing
+end
+
+g()
+mis = union(methodinstances(f), methodinstances(g))
+
+# callhead = :call is the default
+callers1 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis)
+
+# Get the partial-inference case with known number of arguments (this is definitely :call)
+callers2 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Integer, mis; callhead=:call)
+
+# Get the splat call
+callers3 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
+"""
+function findcallers(f, argmatch::Union{Function,Nothing}, mis::AbstractVector{Core.MethodInstance};
+                     callhead::Symbol=:call, world=typemax(UInt), interp=Core.Compiler.NativeInterpreter(world))
+    callhead === :call || callhead === :invoke || callhead === :iterate || error(":call and :invoke are supported, got ", callhead)
+    # if callhead === :iterate
+    #     return findcallers(mis, GlobalRef(Core, :_apply_iterate), argt->(argtargmatch(argt[4:end]); callhead=:call)
+    # end
+    extract(a) = isa(a, Core.Const) ? typeof(a.val) :
+                 isa(a, Core.PartialStruct) ? (a.typ <: Tuple{Any} ? a.typ.parameters[1] : a.typ) :
+                 isa(a,Type) ? a : typeof(a)
+    # Construct a GlobalRef version of `f`
+    ref = GlobalRef(parentmodule(f), nameof(f))
+    callers = Tuple{MethodInstance,CodeInfo,Int,Vector{Any}}[]
+    srcs = CodeInfo[]
+    for item in mis
+        empty!(srcs)
+        try
+            get_typed_instances!(srcs, item, world, interp)
+        catch err
+            # println("skipping ", item, ": ", err)
+            continue
+        end
+        for src in srcs
+            for (i, stmt) in enumerate(src.code)
+                if isa(stmt, Expr)
+                    g = nothing
+                    if stmt.head === :(=)
+                        stmt = stmt.args[2]   # call must come from right hand side of assignment
+                        isa(stmt, Expr) || continue
+                    end
+                    stmt = stmt::Expr
+                    if callhead === :iterate && stmt.head === :call && isglobalref(stmt.args[1], Core, :_apply_iterate)
+                        if isa(stmt.args[3], GlobalRef)  # TODO: handle SSAValues?
+                            g = stmt.args[3]::GlobalRef
+                        end
+                    elseif stmt.head === callhead && isa(stmt.args[1], GlobalRef)  # TODO: handle SSAValue?
+                        g = stmt.args[1]::GlobalRef
+                    end
+                    if isa(g, GlobalRef)
+                        if isglobalref(g, ref.mod, ref.name) ||
+                           (isdefined(g.mod, g.name) && getfield(g.mod, g.name) === f)
+                            # Collect the arg types
+                            argtypes = []
+                            for i = (callhead === :iterate ? 4 : 2):length(stmt.args)
+                                a = stmt.args[i]
+                                if isa(a, Core.SSAValue)
+                                    push!(argtypes, extract(src.ssavaluetypes[a.id]))
+                                elseif isa(a, Core.SlotNumber)
+                                    push!(argtypes, extract(src.slottypes[a.id]))
+                                else
+                                    push!(argtypes, extract(a))
+                                end
+                            end
+                            # Check whether the types match
+                            if argmatch === nothing
+                                push!(callers, (item, src, i, argtypes))
+                                break
+                            else
+                                if argmatch(argtypes)
+                                    push!(callers, (item, src, i, argtypes))
+                                    break
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return callers
+end
+
+isglobalref(@nospecialize(g), mod::Module, name::Symbol) = isa(g, GlobalRef) && g.mod === mod && g.name === name
+
+
+# AbstractTrees interface
 AbstractTrees.children(mi::MethodInstance) = isdefined(mi, :backedges) ? mi.backedges : []
+
+# deprecations
+@deprecate instance methodinstance
 
 end # module

--- a/src/findcallers.jl
+++ b/src/findcallers.jl
@@ -1,0 +1,143 @@
+export findcallers
+
+function get_typed_instances!(srcs, mi::MethodInstance, world, interp)
+    # This is essentially take from code_typed_by_type
+    tt = mi.specTypes
+    matches = Base._methods_by_ftype(tt, -1, world)
+    if matches === false
+        error("signature $(item.specTypes) does not correspond to a generic function")
+    end
+    for match in matches
+        match.method == mi.def || continue
+        meth = Base.func_for_method_checked(match.method, tt, match.sparams)
+        (src, ty) = isdefined(Core.Compiler, :NativeInterpreter) ?
+            Core.Compiler.typeinf_code(interp, meth, match.spec_types, match.sparams, false) :
+            Core.Compiler.typeinf_code(meth, match.spec_types, match.sparams, false, interp)
+        push!(srcs, src)
+    end
+    return srcs
+end
+
+defaultinterp(world) = isdefined(Core.Compiler, :NativeInterpreter) ?
+                       Core.Compiler.NativeInterpreter(world) :
+                       Core.Compiler.Params(world)
+
+function get_typed_instances(mi::MethodInstance; world=typemax(UInt), interp=defaultinterp(world))
+    return get_typed_instances!(CodeInfo[], mi, world, interp)
+end
+
+"""
+    callers = findcallers(f, argmatch::Union{Nothing,Function}, mis; callhead=:call | :iterate)
+
+Find "static" callers of a function `f` with *inferred* argument types for which `argmatch(types)` returns true.
+Optionally pass `nothing` for `argmatch` to allow any calls to `f`.
+`mis` is the list of `MethodInstance`s you want to check, for example obtained from [`methodinstances`](@ref).
+
+`callhead` controls whether you're looking for an ordinary (`:call`) or a splatted (varargs) call (`:iterate`).
+
+`callers` is a vector of tuples `t`, where `t[1]` is the `MethodInstance`, `t[2]` is the corresponding `CodeInfo`,
+`t[3]` is the statement number on which the call occurs, and `t[4]` holds the inferred argument types.
+
+# Examples
+
+```julia
+f(x) = rand()
+function g()
+    a = f(1.0)
+    z = Any[7]
+    b = f(z[1]::Integer)
+    c = f(z...)
+    return nothing
+end
+
+g()
+mis = union(methodinstances(f), methodinstances(g))
+
+# callhead = :call is the default
+callers1 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis)
+
+# Get the partial-inference case with known number of arguments (this is definitely :call)
+callers2 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Integer, mis; callhead=:call)
+
+# Get the splat call
+callers3 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
+
+!!! compat Julia 1.6
+    `findcallers` is available on Julia 1.6 and higher
+
+!!! warn
+    `findcallers` is not guaranteed to find all calls. Calls can be "obfuscated" by many mechanisms,
+    including calls from top level, calls where the function is a runtime variable, etc.
+"""
+function findcallers(f, argmatch::Union{Function,Nothing}, mis::AbstractVector{Core.MethodInstance};
+                     callhead::Symbol=:call, world=typemax(UInt), interp=defaultinterp(world))
+    callhead === :call || callhead === :invoke || callhead === :iterate || error(":call and :invoke are supported, got ", callhead)
+    # if callhead === :iterate
+    #     return findcallers(mis, GlobalRef(Core, :_apply_iterate), argt->(argtargmatch(argt[4:end]); callhead=:call)
+    # end
+    extract(a) = isa(a, Core.Const) ? typeof(a.val) :
+                 isa(a, Core.PartialStruct) ? (a.typ <: Tuple{Any} ? a.typ.parameters[1] : a.typ) :
+                 isa(a,Type) ? a : typeof(a)
+    # Construct a GlobalRef version of `f`
+    ref = GlobalRef(parentmodule(f), nameof(f))
+    callers = Tuple{MethodInstance,CodeInfo,Int,Vector{Any}}[]
+    srcs = CodeInfo[]
+    for item in mis
+        empty!(srcs)
+        try
+            get_typed_instances!(srcs, item, world, interp)
+        catch err
+            # println("skipping ", item, ": ", err)
+            continue
+        end
+        for src in srcs
+            for (i, stmt) in enumerate(src.code)
+                if isa(stmt, Expr)
+                    g = nothing
+                    if stmt.head === :(=)
+                        stmt = stmt.args[2]   # call must come from right hand side of assignment
+                        isa(stmt, Expr) || continue
+                    end
+                    stmt = stmt::Expr
+                    if callhead === :iterate && stmt.head === :call && isglobalref(stmt.args[1], Core, :_apply_iterate)
+                        if isa(stmt.args[3], GlobalRef)  # TODO: handle SSAValues?
+                            g = stmt.args[3]::GlobalRef
+                        end
+                    elseif stmt.head === callhead && isa(stmt.args[1], GlobalRef)  # TODO: handle SSAValue?
+                        g = stmt.args[1]::GlobalRef
+                    end
+                    if isa(g, GlobalRef)
+                        if isglobalref(g, ref.mod, ref.name) ||
+                           (isdefined(g.mod, g.name) && getfield(g.mod, g.name) === f)
+                            # Collect the arg types
+                            argtypes = []
+                            for i = (callhead === :iterate ? 4 : 2):length(stmt.args)
+                                a = stmt.args[i]
+                                if isa(a, Core.SSAValue)
+                                    push!(argtypes, extract(src.ssavaluetypes[a.id]))
+                                elseif isa(a, Core.SlotNumber)
+                                    push!(argtypes, extract(src.slottypes[a.id]))
+                                else
+                                    push!(argtypes, extract(a))
+                                end
+                            end
+                            # Check whether the types match
+                            if argmatch === nothing
+                                push!(callers, (item, src, i, argtypes))
+                                break
+                            else
+                                if argmatch(argtypes)
+                                    push!(callers, (item, src, i, argtypes))
+                                    break
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return callers
+end
+
+isglobalref(@nospecialize(g), mod::Module, name::Symbol) = isa(g, GlobalRef) && g.mod === mod && g.name === name

--- a/src/findcallers.jl
+++ b/src/findcallers.jl
@@ -62,7 +62,7 @@ callers2 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Intege
 # Get the splat call
 callers3 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
 
-!!! compat Julia 1.6
+!!! compat
     `findcallers` is available on Julia 1.6 and higher
 
 !!! warn

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,28 +69,38 @@ end
     end
 end
 
+@testset "methodinstance(s)" begin
+    sum(1:3)
+    mi = methodinstance(sum, (UnitRange{Int},))
+    @test mi isa Core.MethodInstance
+    mis = methodinstances(sum)
+    @test mis isa Vector{Core.MethodInstance}
+    @test mi ∈ mis
+    @test length(mis) > 1
+end
+
 @testset "Backedges" begin
-    mi = instance(Outer.Inner.h, (Int,))
+    mi = methodinstance(Outer.Inner.h, (Int,))
     @test length(all_backedges(mi)) == 2
-    @test terminal_backedges(mi) == [instance(Outer.callcallh, (Int,))]
-    mi = instance(Outer.Inner.h, (Float64,))
+    @test terminal_backedges(mi) == [methodinstance(Outer.callcallh, (Int,))]
+    mi = methodinstance(Outer.Inner.h, (Float64,))
     @test length(all_backedges(mi)) == 1
-    @test terminal_backedges(mi) == [instance(Outer.callh, (Float64,))]
+    @test terminal_backedges(mi) == [methodinstance(Outer.callh, (Float64,))]
     @test all_backedges(mi) == terminal_backedges(mi)
 
     bes = []
     visit_backedges(x->(push!(bes, x); true), Outer.Inner.h)
-    @test instance(Outer.Inner.h, (Int,)) ∈ bes
-    @test instance(Outer.Inner.h, (Float64,)) ∈ bes
-    @test instance(Outer.callh, (Int,)) ∈ bes
-    @test instance(Outer.callh, (Float64,)) ∈ bes
-    @test instance(Outer.callcallh, (Int,)) ∈ bes
+    @test methodinstance(Outer.Inner.h, (Int,)) ∈ bes
+    @test methodinstance(Outer.Inner.h, (Float64,)) ∈ bes
+    @test methodinstance(Outer.callh, (Int,)) ∈ bes
+    @test methodinstance(Outer.callh, (Float64,)) ∈ bes
+    @test methodinstance(Outer.callcallh, (Int,)) ∈ bes
     @test length(bes) == 5
 
     Outer.f2(1, "hello")
     m = which(Outer.f2, (Int, String))
     tt = Tuple{typeof(Outer.f2),Int,String}
-    @test instance(Outer.f2, (Int, String)) === instance(m, tt) === instance(tt)
+    @test methodinstance(Outer.f2, (Int, String)) === methodinstance(m, tt) === methodinstance(tt)
 
     hbes = filter(mi->mi.def ∈ methods(Outer.Inner.h), bes)
     @test length(hbes) == 2
@@ -109,16 +119,16 @@ end
     @test length(bes) == 1
     pr = bes[1]
     @test pr.first == Tuple{typeof(f),Any}
-    @test pr.second == instance(applyf, (Vector{Any},))
+    @test pr.second == methodinstance(applyf, (Vector{Any},))
 
     bes = direct_backedges(f; skip=false)
     @test length(bes) == 2
     pr = bes[1]
     @test pr.first == Tuple{typeof(f),Any}
-    @test pr.second == instance(applyf, (Vector{Any},))
+    @test pr.second == methodinstance(applyf, (Vector{Any},))
     pr = bes[2]
-    @test pr.first == instance(f, (Integer,))
-    @test pr.second == instance(applyf, (Vector{Any},))
+    @test pr.first == methodinstance(f, (Integer,))
+    @test pr.second == methodinstance(applyf, (Vector{Any},))
 end
 
 @testset "call_type" begin
@@ -139,7 +149,7 @@ function applyf(container)
 end
 applyf(Any[1, true])
 
-const w = worlds(instance(applyf, (Vector{Any},)))
+const w = worlds(methodinstance(applyf, (Vector{Any},)))
 const src = code_typed(applyf, (Vector{Any},))[1]
 f(::Bool) = 2
 applyf(Any[1, true])
@@ -148,9 +158,48 @@ end
 @testset "Invalidation" begin
     if VERSION >= v"1.2"
         src, w = Invalidation.src, Invalidation.w
-        mi = instance(Invalidation.applyf, (Vector{Any},))
+        mi = methodinstance(Invalidation.applyf, (Vector{Any},))
         @test MethodAnalysis.equal(src, src)
         @test worlds(mi) != w
         @test !MethodAnalysis.equal(src, code_typed(Invalidation.applyf, (Vector{Any},))[1])
     end
+end
+
+module Callers
+
+f(x) = rand()
+function g()
+    x = sin(π/2)
+    y = f(x)
+    z = round(Int, x)
+    y = f(z)
+    n = Any[7]
+    a = f(n[1])
+    b = f(n[1]::Integer)
+    c = f(n...)
+    return nothing
+end
+
+end
+
+@testset "findcallers" begin
+    Callers.g()
+    mis = methodinstances(Callers)
+    mi = methodinstance(Callers.g, ())
+    # Why are there no `:invoke`s, only `:call`s?
+    callers1 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis; callhead=:invoke)
+    callers2 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Int, mis; callhead=:invoke)
+    callers3 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Any, mis; callhead=:call)
+    callers4 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Integer, mis; callhead=:call)
+    callers5 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
+    @test_broken callers1[1] == mi && callers1[3] < callers3[3]
+    @test_broken callers2[1] == mi && callers2[3] < callers4[3]
+    # Given that :invoke isn't showing up, grab callers1 & callers2 again
+    callers1 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis; callhead=:call)
+    callers2 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Int, mis; callhead=:call)
+    allcallers = [callers1, callers2, callers3, callers4, callers5]
+    @test all(x->length(x) == 1, allcallers)
+    @test all(x->only(x)[1] == mi, allcallers)
+    stmtid = map(x->only(x)[3], allcallers)
+    @test issorted(stmtid) && length(unique(stmtid)) == 5
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,24 +182,26 @@ end
 
 end
 
-@testset "findcallers" begin
-    Callers.g()
-    mis = methodinstances(Callers)
-    mi = methodinstance(Callers.g, ())
-    # Why are there no `:invoke`s, only `:call`s?
-    callers1 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis; callhead=:invoke)
-    callers2 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Int, mis; callhead=:invoke)
-    callers3 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Any, mis; callhead=:call)
-    callers4 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Integer, mis; callhead=:call)
-    callers5 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
-    @test_broken callers1[1] == mi && callers1[3] < callers3[3]
-    @test_broken callers2[1] == mi && callers2[3] < callers4[3]
-    # Given that :invoke isn't showing up, grab callers1 & callers2 again
-    callers1 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis; callhead=:call)
-    callers2 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Int, mis; callhead=:call)
-    allcallers = [callers1, callers2, callers3, callers4, callers5]
-    @test all(x->length(x) == 1, allcallers)
-    @test all(x->only(x)[1] == mi, allcallers)
-    stmtid = map(x->only(x)[3], allcallers)
-    @test issorted(stmtid) && length(unique(stmtid)) == 5
+if isdefined(MethodAnalysis, :findcallers)
+    @testset "findcallers" begin
+        Callers.g()
+        mis = methodinstances(Callers)
+        mi = methodinstance(Callers.g, ())
+        # Why are there no `:invoke`s, only `:call`s?
+        callers1 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis; callhead=:invoke)
+        callers2 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Int, mis; callhead=:invoke)
+        callers3 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Any, mis; callhead=:call)
+        callers4 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Integer, mis; callhead=:call)
+        callers5 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector{Any}, mis; callhead=:iterate)
+        @test_broken callers1[1] == mi && callers1[3] < callers3[3]
+        @test_broken callers2[1] == mi && callers2[3] < callers4[3]
+        # Given that :invoke isn't showing up, grab callers1 & callers2 again
+        callers1 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Float64, mis; callhead=:call)
+        callers2 = findcallers(Callers.f, argtyps->length(argtyps) == 1 && argtyps[1] === Int, mis; callhead=:call)
+        allcallers = [callers1, callers2, callers3, callers4, callers5]
+        @test all(x->length(x) == 1, allcallers)
+        @test all(x->only(x)[1] == mi, allcallers)
+        stmtid = map(x->only(x)[3], allcallers)
+        @test issorted(stmtid) && length(unique(stmtid)) == 5
+    end
 end


### PR DESCRIPTION
This also renames `instance` to `methodinstance` and implements `methodinstances`. (`instances` already means something different in Base, hence the rename.)