### PR TITLE
findcallers: find more constructors, return a Vector{CallMatch}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -11,7 +11,9 @@ AbstractTrees = "0.3"
 julia = "1"
 
 [extras]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Logging", "Pkg", "Test"]

--- a/src/findcallers.jl
+++ b/src/findcallers.jl
@@ -26,6 +26,18 @@ function get_typed_instances(mi::MethodInstance; world=typemax(UInt), interp=def
     return get_typed_instances!(Tuple{CodeInfo,Core.SimpleVector}[], mi, world, interp)
 end
 
+struct CallMatch
+    mi::MethodInstance
+    src::CodeInfo
+    sparams::SimpleVector
+    line::Int
+    argtypes::Vector{Any}
+end
+
+function Base.show(io::IO, cm::CallMatch)
+    print(io, "CallMatch from ", cm.mi, " on statement ", cm.line, "/", length(cm.src.code), " with inferred argument types ", cm.argtypes)
+end
+
 """
     callers = findcallers(f, argmatch::Union{Nothing,Function}, mis; callhead=:call | :iterate)
 
@@ -72,15 +84,13 @@ callers3 = findcallers(f, argtyps->length(argtyps) == 1 && argtyps[1] === Vector
 function findcallers(f, argmatch::Union{Function,Nothing}, mis::AbstractVector{Core.MethodInstance};
                      callhead::Symbol=:call, world=typemax(UInt), interp=defaultinterp(world))
     callhead === :call || callhead === :invoke || callhead === :iterate || error(":call and :invoke are supported, got ", callhead)
-    # if callhead === :iterate
-    #     return findcallers(mis, GlobalRef(Core, :_apply_iterate), argt->(argtargmatch(argt[4:end]); callhead=:call)
-    # end
-    extract(a) = isa(a, Core.Const) ? Core.Typeof(a.val) :
-                 isa(a, Core.PartialStruct) ? (a.typ <: Tuple{Any} ? a.typ.parameters[1] : a.typ) :
-                 isa(a,Type) ? a : Core.Typeof(a)
+    # Check that f is not a type with specified parameters
+    if f isa DataType && !isempty(f.parameters)
+        throw(ArgumentError("findcallers does not support constructor calls with type parameters, got $f. Pass in the type without parameters."))
+    end
     # Construct a GlobalRef version of `f`
     ref = GlobalRef(parentmodule(f), nameof(f))
-    callers = Tuple{MethodInstance,CodeInfo,Int,Vector{Any}}[]
+    callers = CallMatch[]
     srcs = Tuple{CodeInfo,Core.SimpleVector}[]
     for item in mis
         empty!(srcs)
@@ -93,49 +103,64 @@ function findcallers(f, argmatch::Union{Function,Nothing}, mis::AbstractVector{C
         for (src, sparams) in srcs
             for (i, stmt) in enumerate(src.code)
                 if isa(stmt, Expr)
-                    g = nothing
                     if stmt.head === :(=)
                         stmt = stmt.args[2]   # call must come from right hand side of assignment
                         isa(stmt, Expr) || continue
                     end
                     stmt = stmt::Expr
-                    if callhead === :iterate && stmt.head === :call && isglobalref(stmt.args[1], Core, :_apply_iterate)
-                        if isa(stmt.args[3], GlobalRef)  # TODO: handle SSAValues?
-                            g = stmt.args[3]::GlobalRef
-                        end
-                    elseif stmt.head === callhead && isa(stmt.args[1], GlobalRef)  # TODO: handle SSAValue?
-                        g = stmt.args[1]::GlobalRef
+                    callee = nothing
+                    if stmt.head === callhead
+                        callee = stmt.args[1]
+                    elseif callhead === :iterate && stmt.head === :call && isglobalref(stmt.args[1], Core, :_apply_iterate)
+                        callee = stmt.args[3]
                     end
-                    if isa(g, GlobalRef)
-                        if isglobalref(g, ref.mod, ref.name) ||
-                           (isdefined(g.mod, g.name) && getfield(g.mod, g.name) === f)
-                            # Collect the arg types
-                            argtypes = []
-                            for i = (callhead === :iterate ? 4 : 2):length(stmt.args)
-                                a = stmt.args[i]
-                                if isa(a, Core.SSAValue)
-                                    push!(argtypes, extract(src.ssavaluetypes[a.id]))
-                                elseif isa(a, Core.SlotNumber)
-                                    push!(argtypes, extract(src.slottypes[a.id]))
-                                elseif isa(a, GlobalRef)
-                                    push!(argtypes, Core.Typeof(getfield(a.mod, a.name)))
-                                elseif isexpr(a, :static_parameter)
-                                    a = a::Expr
-                                    push!(argtypes, Type{sparams[a.args[1]::Int]})
-                                else
-                                    push!(argtypes, extract(a))
-                                end
-                            end
-                            # Check whether the types match
-                            if argmatch === nothing
-                                push!(callers, (item, src, i, argtypes))
-                                break
-                            else
-                                if argmatch(argtypes)
-                                    push!(callers, (item, src, i, argtypes))
-                                    break
-                                end
-                            end
+                    callee === nothing && continue
+                    if isa(callee, Core.SSAValue)
+                        callee = try
+                            eval_ssa(src, sparams, callee.id)
+                        catch err
+                            @show src i
+                            throw(err)
+                        end
+                    end
+                    matches = false
+                    if callee === f
+                        matches = true
+                    elseif isa(callee, GlobalRef)
+                        if isglobalref(callee, ref.mod, ref.name) ||
+                           (isdefined(callee.mod, callee.name) && getfield(callee.mod, callee.name) === f)
+                            matches = true
+                        end
+                    elseif isa(f, Type) && isa(callee, DataType) && !isempty(callee.parameters)
+                        # This came from a `typeof(a)(b)` call
+                        matches = callee <: f
+                    end
+                    matches || continue
+                    # Collect the arg types
+                    argtypes = []
+                    for i = (callhead === :iterate ? 4 : 2):length(stmt.args)
+                        a = stmt.args[i]
+                        if isa(a, Core.SSAValue)
+                            push!(argtypes, extract(src.ssavaluetypes[a.id], sparams))
+                        elseif isa(a, Core.SlotNumber)
+                            push!(argtypes, extract(src.slottypes[a.id], sparams))
+                        elseif isa(a, GlobalRef)
+                            push!(argtypes, Core.Typeof(getfield(a.mod, a.name)))
+                        elseif isexpr(a, :static_parameter)
+                            a = a::Expr
+                            push!(argtypes, Type{sparams[a.args[1]::Int]})
+                        else
+                            push!(argtypes, extract(a, sparams))
+                        end
+                    end
+                    # Check whether the types match
+                    if argmatch === nothing
+                        push!(callers, CallMatch(item, src, sparams, i, argtypes))
+                        break
+                    else
+                        if argmatch(argtypes)
+                            push!(callers, CallMatch(item, src, sparams, i, argtypes))
+                            break
                         end
                     end
                 end
@@ -146,3 +171,41 @@ function findcallers(f, argmatch::Union{Function,Nothing}, mis::AbstractVector{C
 end
 
 isglobalref(@nospecialize(g), mod::Module, name::Symbol) = isa(g, GlobalRef) && g.mod === mod && g.name === name
+
+extract(a, sparams) = isa(a, Core.Const) ? Core.Typeof(a.val) :
+                      isa(a, Core.PartialStruct) ? (a.typ <: Tuple{Any} ? a.typ.parameters[1] : a.typ) :
+                      isa(a,Type) ? a :
+                      isexpr(a, :static_parameter) ? sparams[(a::Expr).args[1]] :
+                      Core.Typeof(a)
+
+# This is deliberately simple to prevent performance from tanking
+function eval_ssa(src, sparams, id)
+    stmt = src.code[id]
+    if isa(stmt, Expr)
+        if stmt.head === :call
+            callee = stmt.args[1]
+            if isglobalref(callee, Core, :apply_type)
+                return stmt.args[2]
+            elseif isglobalref(callee, Base, :getproperty)
+                modg, objq = stmt.args[2], stmt.args[3]
+                if isa(modg, Core.SSAValue)
+                    modg = eval_ssa(src, sparams, modg.id)
+                end
+                if isa(modg, GlobalRef)
+                    isdefined(modg.mod, modg.name) || return nothing
+                    mod = getfield(modg.mod, modg.name)
+                    objname = objq.value::Symbol
+                    return GlobalRef(mod, objname)
+                end
+            elseif isglobalref(callee, Core, :kwfunc)
+                return stmt.args[2]
+            elseif isa(callee, GlobalRef) && callee.name === :typeof && length(stmt.args) == 2
+                isa(stmt.args[2], Core.SlotNumber) && return src.slottypes[(stmt.args[2]::Core.SlotNumber).id]
+                isa(stmt.args[2], Core.SSAValue) && return eval_ssa(src, sparams, (stmt.args[2]::Core.SSAValue).id)
+            end
+        end
+    end
+    isa(stmt, GlobalRef) && return stmt
+    isa(stmt, QuoteNode) && return stmt.value
+    return src.ssavaluetypes[id]
+end


### PR DESCRIPTION
Previously, `findcallers` was incapable of finding constructor calls. This supports "untyped" constructor calls (`Vector(x)` but not `Vector{Int}(x)`), reasoning that performance matters and a second stage of filtering can be used later. Moreover, really handling the type parameters well will require partial evaluation of the codeinfo, and that seems like a job for JuliaInterpreter and LoweredCodeUtils, but I don't want to add heavy dependencies to this package.

This has been *extremely* useful for tracking down the pesky `similar` invalidations.