### PR TITLE
Don't create methodinstances by looking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/MethodAnalysis.jl
+++ b/src/MethodAnalysis.jl
@@ -89,9 +89,8 @@ MethodInstance for f(::Int64, ::String)
 """
 function methodinstance(@nospecialize(f), @nospecialize(types))
     if types isa Tuple
-        m = which(f, types)
         tt = Tuple{typeof(f), types...}
-        return methodinstance(m, tt)
+        return methodinstance(f, tt)
     end
     inst = nothing
     visit(f) do mi
@@ -107,8 +106,7 @@ function methodinstance(@nospecialize(f), @nospecialize(types))
 end
 function methodinstance(@nospecialize(types))
     f, argt = call_type(types)
-    m = which(f, argt)
-    return methodinstance(m, types)
+    return methodinstance(f, types)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,10 +107,12 @@ end
     @test methodinstance(Outer.callcallh, (Int,)) ∈ bes
     @test length(bes) == 5
 
+    tt = Tuple{typeof(Outer.f2),Int,String}
+    @test methodinstance(tt) === methodinstance(Outer.f2, (Int, String)) === nothing
     Outer.f2(1, "hello")
     m = which(Outer.f2, (Int, String))
-    tt = Tuple{typeof(Outer.f2),Int,String}
     @test methodinstance(Outer.f2, (Int, String)) === methodinstance(m, tt) === methodinstance(tt)
+    @test methodinstance(tt) !== nothing
 
     hbes = filter(mi->mi.def ∈ methods(Outer.Inner.h), bes)
     @test length(hbes) == 2


### PR DESCRIPTION
It turns out that calling `which(f, types)` can *create* new MethodInstances that didn't exist before. We need to avoid doing that when looking for them.