### PR TITLE
Support `direct_backedges(::MethodInstance)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -52,7 +52,7 @@ end
 
 Collect all backedges for a function `f` as pairs `instance=>caller` or `sig=>caller` pairs.
 The latter occur for MethodTable backedges.
-If `skip` is `true`, any `caller` listed in a MethodTable backedge is omitted from the instance backedges. 
+If `skip` is `true`, any `caller` listed in a MethodTable backedge is omitted from the instance backedges.
 """
 function direct_backedges(f::Union{Method,Callable}; skip::Bool=true)
     bes = []
@@ -82,4 +82,18 @@ function direct_backedges(f::Union{Method,Callable}; skip::Bool=true)
         true
     end
     return bes
+end
+
+"""
+    direct_backedges(mi::MethodInstance)
+
+A vector of all direct backedges of `mi`. This is equivalent to `mi.backedges` except that it's "safe,"
+meaning it returns an empty list even when `mi.backedges` is not defined.
+"""
+function direct_backedges(mi::MethodInstance)
+    out = MethodInstance[]
+    if isdefined(mi, :backedges)
+        append!(out, mi.backedges)
+    end
+    return out
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,14 @@ end
     pr = bes[2]
     @test pr.first == methodinstance(f, (Integer,))
     @test pr.second == methodinstance(applyf, (Vector{Any},))
+
+    nocallers(x) = x
+    nocallers(3)
+    mi = methodinstance(nocallers, (Int,))
+    @test isempty(direct_backedges(mi))
+    callnocallers(x) = nocallers(x)
+    callnocallers(3)
+    @test !isempty(direct_backedges(mi))
 end
 
 @testset "call_type" begin


### PR DESCRIPTION
This is a small convenience that avoids the risk of an `UndefRefError`
from `mi.backedges`