### PR TITLE
Add visit_withmodule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/MethodAnalysis.jl
+++ b/src/MethodAnalysis.jl
@@ -6,7 +6,8 @@ using Base: Callable, IdSet
 using Core: MethodInstance, CodeInfo, SimpleVector, MethodTable
 using Base.Meta: isexpr
 
-export visit, call_type, methodinstance, methodinstances, worlds  # findcallers is exported from its own file
+export visit, visit_withmodule
+export call_type, methodinstance, methodinstances, worlds  # findcallers is exported from its own file
 export visit_backedges, all_backedges, with_all_backedges, terminal_backedges, direct_backedges
 export child_modules, methodinstances_owned_by
 export hasbox


### PR DESCRIPTION
This allows the operation to know the module in which
the current item was found. Note that this is distinct
from module ownership:

```julia
module A f(x) = 1 end
module B
    using ..A
    A.f(x::Int) = 2
end
```

In this case both methods are found while traversing A,
even though `which(A.f, (Int,)).module == B`.