### PR TITLE
Collect items from kwfuncs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/visit.jl
+++ b/src/visit.jl
@@ -132,6 +132,13 @@ function _visit(@nospecialize(operation), @nospecialize(f::Callable), visited::I
             _visit(operation, m, visited, print)
         end
     end
+    # isdefined(Base, Symbol("f##kw")) is false but isdefined(Base, Symbol("#f##kw")) is true
+    # (the type of the function is defined but the function itself isn't), so to get kwfunc we
+    # need to look for them specially
+    if !isa(f, Function) && isdefined(f, :instance)
+        finst = f.instance
+        isa(finst, Function) && _visit(operation, finst, visited, print)
+    end
     return nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,8 @@ module Outer
 
     f2(x, y::String) = 2x
     f2(x, y::Number) = x + y
+
+    fkw(x; y=0) = 2x + y
 end
 
 module One
@@ -31,6 +33,18 @@ end
 
 
 @testset "visit" begin
+    # Do we pick up kwfuncs?
+    meths = Set{Method}()
+    visit(Outer) do item
+        if item isa Method
+            push!(meths, item)
+            return false
+        end
+        return true
+    end
+    mkw = only(methods(Core.kwfunc(Outer.fkw)))
+    @test mkw in meths
+
     @test Outer.Inner.g("hi") == 0
     @test Outer.f(nothing) == 1
     @test Outer.callh(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ end
         end
         return true
     end
-    mkw = only(methods(Core.kwfunc(Outer.fkw)))
+    mkw = first(methods(Core.kwfunc(Outer.fkw)))
     @test mkw in meths
 
     @test Outer.Inner.g("hi") == 0


### PR DESCRIPTION
Previously we were missing most kwfunc methods, which turn out to be a bit subtle with respect to what appears in `names(mod; all=true)`.