### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.6'
+          version: '1.10'
           show-versioninfo: true
       - uses: actions/checkout@v4
       - uses: julia-actions/julia-buildpkg@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
+          - 'min'
           - '1'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "MethodAnalysis"
 uuid = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.13"
+version = "1.0.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 
 [compat]
 AbstractTrees = "0.3, 0.4.2"
-julia = "1"
+julia = "1.10"
 
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MethodAnalysis
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://timholy.github.io/MethodAnalysis.jl/stable)
-[![Build Status](https://travis-ci.com/timholy/MethodAnalysis.jl.svg?branch=master)](https://travis-ci.com/timholy/MethodAnalysis.jl)
+[![CI](https://github.com/timholy/MethodAnalysis.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/timholy/MethodAnalysis.jl/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/timholy/MethodAnalysis.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/timholy/MethodAnalysis.jl)
 
 This package is useful for inspecting Julia's internals, particularly its MethodInstances and their backedges. See the documentation for details.


### PR DESCRIPTION
- bump minimum Julia version to 1.10
- update CI to test 'min', '1', and 'pre' Julia versions
- fix CI badge